### PR TITLE
Streamline rendering

### DIFF
--- a/lib/draw/ChoreoRenderer.js
+++ b/lib/draw/ChoreoRenderer.js
@@ -33,8 +33,9 @@ import {
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 // display specific constants that are not part of the BPMNDI standard
-let CHOREO_TASK_ROUNDING = 10;
-let MARKER_HEIGHT = 15;
+const CHOREO_TASK_ROUNDING = 10;
+const MARKER_HEIGHT = 15;
+const DEFAULT_FILL_OPACITY = .95;
 
 /**
  * A renderer for BPMN 2.0 choreography diagrams.
@@ -109,20 +110,47 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
   };
 
   this.drawParticipantBand = function(p, element) {
-    let bandKind = element.diBand.participantBandKind || 'top-initiating';
-    let isInitiating = !bandKind.endsWith('non_initiating');
+    const bandKind = element.diBand.participantBandKind || 'top-initiating';
+    const isInitiating = !bandKind.endsWith('non_initiating');
+    const isTop = bandKind.startsWith('top');
+    const isBottom = bandKind.startsWith('bottom');
+    const isMiddle = !isTop && !isBottom;
 
     // draw the participant band
     let bandShape = svgCreate('path');
     svgAttr(bandShape, {
       d: getParticipantBandOutline(0, 0, element.width, element.height, bandKind),
-      stroke: '#000000',
-      strokeWidth: 2,
-      fill: isInitiating ? 'white' : 'lightgray',
-      fillOpacity: 1,
+      fill: isInitiating ? 'white' : 'black',
+      fillOpacity: isInitiating ? 0 : 0.1725,
     });
     svgAppend(p, bandShape);
     attachMarkerToParticipant(p, element);
+
+    // add the line(s)
+    if (isTop || isMiddle) {
+      let line = svgCreate('path');
+      svgAttr(line, {
+        d: componentsToPath([
+          ['M', 0, element.height],
+          ['l', element.width, 0]
+        ]),
+        stroke: 'black',
+        strokeWidth: 2
+      });
+      svgAppend(p, line);
+    }
+    if (isBottom || isMiddle) {
+      let line = svgCreate('path');
+      svgAttr(line, {
+        d: componentsToPath([
+          ['M', 0, 0],
+          ['l', element.width, 0]
+        ]),
+        stroke: 'black',
+        strokeWidth: 2
+      });
+      svgAppend(p, line);
+    }
 
     // add the name of the participant
     let label = getBoxedLabel(element.businessObject.name, {
@@ -141,6 +169,7 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
     svgAttr(shape, {
       d: getTaskOutline(0, 0, element.width, element.height, is(element, 'bpmn:CallChoreography') ? 2 : 0),
       fill: 'white',
+      fillOpacity: DEFAULT_FILL_OPACITY,
       stroke: 'black',
       strokeWidth: is(element, 'bpmn:CallChoreography') ? 6 : 2
     });

--- a/lib/draw/ChoreoRenderer.js
+++ b/lib/draw/ChoreoRenderer.js
@@ -69,8 +69,6 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
     let isBottom = bandKind.startsWith('bottom');
     let isInitiating = !bandKind.endsWith('non_initiating');
 
-    let group = svgCreate('g');
-
     // first, draw the connecting dotted line
     let connector = svgCreate('path');
     svgAttr(connector, {
@@ -83,7 +81,7 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
       strokeDasharray: '0, 4',
       strokeLinecap: 'round'
     });
-    svgAppend(group, connector);
+    svgAppend(p, connector);
 
     // then, draw the envelope
     let envelope = svgCreate('path');
@@ -94,7 +92,7 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
       fill: isInitiating ? 'white' : 'lightgray',
       fillOpacity: 1,
     });
-    svgAppend(group, envelope);
+    svgAppend(p, envelope);
 
     // then, attach the label
     if (element.businessObject.name) {
@@ -104,15 +102,13 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
         width: element.parent.width,
         height: element.height
       }, 'center-middle');
-      svgAppend(group, label);
+      svgAppend(p, label);
     }
 
-    svgAppend(p, group);
-    return group;
+    return p;
   };
 
   this.drawParticipantBand = function(p, element) {
-    let group = svgCreate('g');
     let bandKind = element.diBand.participantBandKind || 'top-initiating';
     let isInitiating = !bandKind.endsWith('non_initiating');
 
@@ -125,8 +121,8 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
       fill: isInitiating ? 'white' : 'lightgray',
       fillOpacity: 1,
     });
-    svgAppend(group, bandShape);
-    attachMarkerToParticipant(group, element);
+    svgAppend(p, bandShape);
+    attachMarkerToParticipant(p, element);
 
     // add the name of the participant
     let label = getBoxedLabel(element.businessObject.name, {
@@ -135,15 +131,12 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
       width: element.width,
       height: element.height - ((hasBandMarker(element.businessObject)) ? MARKER_HEIGHT : 0)
     }, 'center-middle');
-    svgAppend(group, label);
+    svgAppend(p, label);
 
-    svgAppend(p, group);
-    return group;
+    return p;
   };
 
   this.drawChoreographyActivity = function(p, element) {
-    let group = svgCreate('g');
-
     let shape = svgCreate('path');
     svgAttr(shape, {
       d: getTaskOutline(0, 0, element.width, element.height, is(element, 'bpmn:CallChoreography') ? 2 : 0),
@@ -151,9 +144,9 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
       stroke: 'black',
       strokeWidth: is(element, 'bpmn:CallChoreography') ? 6 : 2
     });
-    svgAppend(group, shape);
+    svgAppend(p, shape);
 
-    let hasMarkers = attachMarkerToChoreoActivity(group, element);
+    let hasMarkers = attachMarkerToChoreoActivity(p, element);
 
     let top = heightOfTopBands(element);
     let bottom = element.height - heightOfBottomBands(element) - (hasMarkers ? 20 : 0);
@@ -167,10 +160,9 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
       width: element.width,
       height: bottom - top
     }, align);
-    svgAppend(group, label);
+    svgAppend(p, label);
 
-    svgAppend(p, group);
-    return group;
+    return print;
   };
 
   function attachMarkerToChoreoActivity(parentGfx, element) {

--- a/lib/draw/ChoreoRenderer.js
+++ b/lib/draw/ChoreoRenderer.js
@@ -36,6 +36,7 @@ import { is } from 'bpmn-js/lib/util/ModelUtil';
 const CHOREO_TASK_ROUNDING = 10;
 const MARKER_HEIGHT = 15;
 const DEFAULT_FILL_OPACITY = .95;
+const NON_INITIATING_OPACITY = .1725;
 
 /**
  * A renderer for BPMN 2.0 choreography diagrams.
@@ -84,14 +85,26 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
     });
     svgAppend(p, connector);
 
+    // draw background
+    let rect = svgCreate('rect');
+    svgAttr(rect, {
+      x: 0,
+      y: 0,
+      width: element.width,
+      height: element.height,
+      fill: 'white',
+      fillOpacity: DEFAULT_FILL_OPACITY,
+    });
+    svgAppend(p, rect);
+
     // then, draw the envelope
     let envelope = svgCreate('path');
     svgAttr(envelope, {
       d: getEnvelopePath(element.width, element.height),
-      stroke: '#000000',
+      stroke: 'black',
       strokeWidth: 2,
-      fill: isInitiating ? 'white' : 'lightgray',
-      fillOpacity: 1,
+      fill: isInitiating ? 'white' : 'black',
+      fillOpacity: isInitiating ? 0 : NON_INITIATING_OPACITY,
     });
     svgAppend(p, envelope);
 
@@ -121,7 +134,7 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
     svgAttr(bandShape, {
       d: getParticipantBandOutline(0, 0, element.width, element.height, bandKind),
       fill: isInitiating ? 'white' : 'black',
-      fillOpacity: isInitiating ? 0 : 0.1725,
+      fillOpacity: isInitiating ? 0 : NON_INITIATING_OPACITY
     });
     svgAppend(p, bandShape);
     attachMarkerToParticipant(p, element);
@@ -340,8 +353,12 @@ export default function ChoreoRenderer(eventBus, styles, textRenderer, pathMap) 
 
 inherits(ChoreoRenderer, BaseRenderer);
 
-ChoreoRenderer.$inject = ['eventBus', 'styles', 'textRenderer', 'pathMap'];
-
+ChoreoRenderer.$inject = [
+  'eventBus',
+  'styles',
+  'textRenderer',
+  'pathMap'
+];
 
 ChoreoRenderer.prototype.canRender = function(element) {
   return is(element, 'bpmn:ChoreographyActivity') ||


### PR DESCRIPTION
Resolves #22 

This PR changes the rendering pipeline to be more similar to bpmn-js in its output.
It gets rid of superfluous SVG groups, and makes elements slightly translucent as in bpmn-js.