### PR TITLE
Fix minimum size of activities

### DIFF
--- a/lib/features/modeling/ChoreoModeling.js
+++ b/lib/features/modeling/ChoreoModeling.js
@@ -14,6 +14,7 @@ import ChoreoPasteHandler from './cmd/ChoreoPasteHandler';
 import ChoreoAppendShapeHandler from './cmd/ChoreoAppendShapeHandler';
 import LinkCallChoreoHandler from './cmd/LinkCallChoreoHandler';
 import LinkCallChoreoParticipantHandler from './cmd/LinkCallChoreoParticipantHandler';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 /**
  * Component that manages choreography specific modeling moves that attach to the
@@ -140,4 +141,25 @@ ChoreoModeling.prototype.unlinkCallChoreoParticipants = function(element) {
       element: element,
       outerParticipant: pa.outerParticipantRef
     }));
+};
+
+/**
+ * This function overwrites the one from diagram-js. Crucially we need to filter out all the participants
+ * or else they are moved twice, as they are nested in the activity and then moved again seperately.
+ * #review: Alternatively this issue could be fixed by overwriting space tool handler
+ * @param movingShapes
+ * @param resizingShapes
+ * @param delta
+ * @param direction
+ */
+ChoreoModeling.prototype.createSpace = function(movingShapes, resizingShapes, delta, direction) {
+  movingShapes = movingShapes.filter(s => !is(s, 'bpmn:Participant'));
+  var context = {
+    movingShapes: movingShapes,
+    resizingShapes: resizingShapes,
+    delta: delta,
+    direction: direction
+  };
+
+  this._commandStack.execute('spaceTool', context);
 };

--- a/lib/features/resize/ChoreoResize.js
+++ b/lib/features/resize/ChoreoResize.js
@@ -31,7 +31,7 @@ ChoreoResize.prototype.computeMinResizeBox = function(context) {
 
     minDimensions = context.minDimensions || {
       width: 100,
-      height: topBandsHeight + bottomBandsHeight + 50
+      height: topBandsHeight + bottomBandsHeight + 40
     };
 
     // get children we want to factor in in determining the bounds (only when not collapsed)


### PR DESCRIPTION
Activities now have a consistent minimum size and can now return to their original size after prior resizing. Resolves #109 