### PR TITLE
(Really) fix removing the first choreography

### DIFF
--- a/lib/features/utils/ChoreoUtil.js
+++ b/lib/features/utils/ChoreoUtil.js
@@ -29,7 +29,7 @@ export default class ChoreoUtil {
 
   removeChoreographyById(choreoId) {
     const choreoIndex = this.definitions().rootElements.findIndex((choreography) => choreography.id === choreoId);
-    if (choreoIndex) {
+    if (choreoIndex >= 0) {
       this.definitions().rootElements.splice(choreoIndex, 1);
     } else {
       throw new Error('could not find choreography with ID ' + choreoId);


### PR DESCRIPTION
A followup to #126 where we forgot one condition that makes removing a choreography fail if it is at index 0 of `rootElements`.