### PR TITLE
Allow loading of diagrams from JSON definitions object

### DIFF
--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -19,6 +19,7 @@ import SwitchModule from './features/switch';
 
 import {
   setXML,
+  setDefinitions,
   displayChoreography
 } from './import/ImportHandler';
 
@@ -39,6 +40,13 @@ Modeler.prototype.displayChoreography = function(options) {
 Modeler.prototype.importXML = function(xml, options) {
   const self = this;
   return setXML(this, xml, options).then(() => {
+    return displayChoreography(self, options);
+  });
+};
+
+Modeler.prototype.importDefinitions = function(definitions, options) {
+  const self = this;
+  return setDefinitions(this, definitions, options).then(() => {
     return displayChoreography(self, options);
   });
 };

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -7,6 +7,7 @@ import CoreModule from './core';
 
 import {
   setXML,
+  setDefinitions,
   displayChoreography
 } from './import/ImportHandler';
 
@@ -37,6 +38,13 @@ Viewer.prototype.displayChoreography = function(options) {
 Viewer.prototype.importXML = function(xml, options) {
   const self = this;
   return setXML(this, xml, options).then(() => {
+    return displayChoreography(self, options);
+  });
+};
+
+Viewer.prototype.importDefinitions = function(definitions, options) {
+  const self = this;
+  return setDefinitions(this, definitions, options).then(() => {
     return displayChoreography(self, options);
   });
 };

--- a/lib/import/ImportHandler.js
+++ b/lib/import/ImportHandler.js
@@ -42,6 +42,29 @@ export function setXML(viewer, xml, options) {
 }
 
 /**
+ * Sets the underlying model of the viewer.
+ * The model must be given as parsed definitions object from bpmn-moddle.
+ *
+ * @param {Object} viewer the viewer to which to attach the definitions to
+ * @param {String} definitions the definitions object
+ * @param {Object} [options] additional options
+ */
+export function setDefinitions(viewer, definitions, options) {
+  return new Promise((resolve, reject) => {
+    // clear old diagram if there is one and clear the cache
+    if (viewer._definitions) {
+      viewer.clear();
+    }
+    shapeCache = {};
+
+    // change definitions and inform listeners
+    viewer._definitions = definitions;
+    viewer._emit('import.done');
+    resolve();
+  });
+}
+
+/**
  * Display a specific choreography contained in the definitions attached to a viewer.
  *
  * @param {Object} viewer the viewer to use for displaying

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chor-js",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A BPMN 2.0 choreography diagram rendering toolkit and web modeler.",
   "keywords": [
     "choreography model",


### PR DESCRIPTION
This PR allows users to directly pass a JSON definitions object to chor-js instead of a serialized XML string.

Usage:

```javascript
var moddle = new BpmnModdle();
var xml = '<?xml version="1.0" encoding="UTF-8"?>[...]';

moddle.fromXML(xml, function(err, definitions) {
  modeler.importDefinitions(definitions);
});
```