### PR TITLE
Decouple the TreeWalker from ImportHandler 

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -83,6 +83,6 @@ Viewer.prototype._collectIds = function(definitions, context) {
 
 Viewer.prototype._modules = [].concat(
   Viewer.prototype._modules, [
-    CoreModule,
+    CoreModule
   ]
 );

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -83,6 +83,6 @@ Viewer.prototype._collectIds = function(definitions, context) {
 
 Viewer.prototype._modules = [].concat(
   Viewer.prototype._modules, [
-    CoreModule
+    CoreModule,
   ]
 );

--- a/lib/import/ChoreoTreeWalker.js
+++ b/lib/import/ChoreoTreeWalker.js
@@ -12,9 +12,16 @@ import {
  * @param {*} visitor
  */
 export default class ChoreoTreeWalker {
-  constructor(visitor) {
-    this._visitor = visitor;
+  constructor() {
     this._deferred = [];
+  }
+
+  /**
+   * Before each run, the correct visitor e.g., cached or not cached has to be set.
+   * @param visitor
+   */
+  setVisitor(visitor) {
+    this._visitor = visitor;
   }
 
   /**

--- a/lib/import/ChoreoTreeWalker.js
+++ b/lib/import/ChoreoTreeWalker.js
@@ -23,7 +23,7 @@ export default class ChoreoTreeWalker {
   setVisitor(visitor) {
     this._visitor = visitor;
     if (this._deferred.length !== 0) {
-      throw new Error('Before setting a new Visitor not all Objects in deferred have been visited');
+      throw new Error('Before setting a new visitor not all objects in deferred have been visited');
     }
   }
 

--- a/lib/import/ChoreoTreeWalker.js
+++ b/lib/import/ChoreoTreeWalker.js
@@ -22,6 +22,9 @@ export default class ChoreoTreeWalker {
    */
   setVisitor(visitor) {
     this._visitor = visitor;
+    if (this._deferred.length !== 0) {
+      throw new Error('Before setting a new Visitor not all Objects in deferred have been visited');
+    }
   }
 
   /**

--- a/lib/import/ImportHandler.js
+++ b/lib/import/ImportHandler.js
@@ -175,7 +175,7 @@ export function displayChoreography(viewer, options) {
 
     // legacy: the test bootstrapper will pass a callback as the options object,
     // which we have to call
-    if (typeof (options) == 'function') {
+    if (typeof(options) == 'function') {
       options();
     }
     return resolve();

--- a/lib/import/ImportHandler.js
+++ b/lib/import/ImportHandler.js
@@ -1,5 +1,3 @@
-import ChoreoTreeWalker from './ChoreoTreeWalker';
-
 let shapeCache = {};
 
 /**
@@ -167,14 +165,17 @@ export function displayChoreography(viewer, options) {
       visitor = viewer.get('initialRenderVisitor');
     }
 
+    // we get the walker from viewer, so it can be replaced by a different one if needed.
+    let walker = viewer.get('treeWalker');
+    walker.setVisitor(visitor);
+
     // start the walker
-    let walker = new ChoreoTreeWalker(visitor);
     walker.start(choreo, diagram);
     eventBus.fire('import.render.complete');
 
     // legacy: the test bootstrapper will pass a callback as the options object,
     // which we have to call
-    if (typeof(options) == 'function') {
+    if (typeof (options) == 'function') {
       options();
     }
     return resolve();

--- a/lib/import/index.js
+++ b/lib/import/index.js
@@ -1,7 +1,9 @@
 import VisitorModule from './visitors';
+import ChoreoTreeWalker from './ChoreoTreeWalker';
 
 export default {
   __depends__: [
     VisitorModule
-  ]
+  ],
+  treeWalker: [ 'type', ChoreoTreeWalker ],
 };


### PR DESCRIPTION
Make the TreeWalker accessible via Viewer. This way a tool that uses chor-js can replace the walker with a different implementation.