### PR TITLE
Fix restore

### DIFF
--- a/lib/import/visitors/RestoreFromCacheVisitor.js
+++ b/lib/import/visitors/RestoreFromCacheVisitor.js
@@ -66,7 +66,7 @@ RestoreFromCacheVisitor.prototype.getShape = function(element, parentShape) {
 
   return this._cache.find(shape => {
     // shape must not be of type label, as the label has the same business object as as the element it belongs to.
-    if (shape.type === 'label' || shape.businessObject !== element ) {
+    if (shape.type === 'label' || shape.businessObject !== element) {
       return false;
     }
 

--- a/lib/import/visitors/RestoreFromCacheVisitor.js
+++ b/lib/import/visitors/RestoreFromCacheVisitor.js
@@ -65,7 +65,8 @@ RestoreFromCacheVisitor.prototype.getShape = function(element, parentShape) {
   }
 
   return this._cache.find(shape => {
-    if (shape.businessObject !== element) {
+    // shape must not be of type label, as the label has the same business object as as the element it belongs to.
+    if (shape.type === 'label' || shape.businessObject !== element ) {
       return false;
     }
 


### PR DESCRIPTION
Fixes a bug where restore from cache crashed because of adding a label twice.

This happened for external labels who belonged to elements whose type was changed, e.g. Start Event to Timer Start Event, because the labels where mistaken for the actual timer element as their business objects are the same.