### PR TITLE
Fix sequence flow connection

### DIFF
--- a/lib/features/rules/ChoreoRules.js
+++ b/lib/features/rules/ChoreoRules.js
@@ -33,6 +33,8 @@ ChoreoRules.$inject = ['injector'];
 ChoreoRules.prototype.init = function() {
   let self = this;
 
+  // START: Rules from bpmn-js, only the calls to the functions via self are changed
+
   this.addRule('connection.create', function(context) {
     // This function is equivalent to bpmn-js 6.5.1 except for self.canConnect
     var source = context.source,
@@ -82,6 +84,8 @@ ChoreoRules.prototype.init = function() {
   });
 
   this.addRule('elements.create', function(context) {
+    // This function is equivalent to bpmn-js 6.5.1 except for self calls and every function
+    // WARNING THIS BROUGHT IN NEW FUNCTIONS AND MIGHT BREAK STUFF
     var elements = context.elements,
         position = context.position,
         target = context.target;
@@ -98,6 +102,52 @@ ChoreoRules.prototype.init = function() {
       return self.canCreate(element, target, null, position);
     });
   });
+
+  this.addRule('elements.move', function(context) {
+    // This function is equivalent to bpmn-js 6.5.1 except for self calls
+    var target = context.target,
+        shapes = context.shapes,
+        position = context.position;
+
+    return self.canAttach(shapes, target, null, position) ||
+      self.canReplace(shapes, target, position) ||
+      self.canMove(shapes, target, position) ||
+      self.canInsert(shapes, target, position);
+  });
+
+  this.addRule('shape.create', function(context) {
+    // This function is equivalent to bpmn-js 6.5.1 except for self call
+    return self.canCreate(
+      context.shape,
+      context.target,
+      context.source,
+      context.position
+    );
+  });
+
+  this.addRule('shape.attach', function(context) {
+    // This function is equivalent to bpmn-js 6.5.1 except for self call
+    return self.canAttach(
+      context.shape,
+      context.target,
+      null,
+      context.position
+    );
+  });
+
+  this.addRule('element.copy', function(context) {
+    // This function is equivalent to bpmn-js 6.5.1 except for self call
+    // It looks a bit like an oversight that this is still called and it might break in the future.
+    // According to the changelog of diagram-js 4 it should have been replaced with copyPaste.canCopyElements but wasn't
+    var elements = context.elements,
+        element = context.element;
+    return self.canCopy(elements, element);
+  });
+
+  // END: Rules from bpmn-js
+
+
+  // START: Chor-js specific rules
 
   this.addRule('band.create', function(context) {
     let activityShape = context.activityShape;
@@ -170,58 +220,6 @@ ChoreoRules.prototype.init = function() {
     });
   });
 
-
-
-  this.addRule('elements.create', function(context) {
-    console.log(context);
-
-  });
-
-  this.addRule('elements.move', function(context) {
-    var target = context.target,
-        shapes = context.shapes,
-        position = context.position;
-
-    return self.canAttach(shapes, target, null, position) ||
-           self.canReplace(shapes, target, position) ||
-           self.canMove(shapes, target, position) ||
-           self.canInsert(shapes, target, position);
-  });
-
-  this.addRule('shape.create', function(context) {
-    return self.canCreate(
-      context.shape,
-      context.target,
-      context.source,
-      context.position
-    );
-  });
-
-  this.addRule('shape.attach', function(context) {
-    return self.canAttach(
-      context.shape,
-      context.target,
-      null,
-      context.position
-    );
-  });
-
-  function canCopyChoreo(element, collection) {
-    if (isAny(element, ['bpmn:Participant', 'bpmn:Message'])) {
-      return false;
-    }
-    return true;
-  }
-
-  this.addRule('element.copy', function(context) {
-    // It looks a bit like an oversight that this is still called and it might break in the future.
-    // According to the changelog of diagram-js 4 it should have been replaced with copyPaste.canCopyElements but wasn't
-    var collection = context.elements,
-        element = context.element;
-    const bpmnCanCopy = self.canCopy(collection, element);
-    let choreoCanCopy = canCopyChoreo(element, collection);
-    return bpmnCanCopy && choreoCanCopy;
-  });
 
   this.addRule('band.canInitiatingBeSwapped', function(context) {
     const bandShape = context.bandShape;
@@ -302,3 +300,10 @@ ChoreoRules.prototype.canConnectSequenceFlow = function(source, target) {
 function isConnection(element) {
   return element.waypoints;
 }
+
+ChoreoRules.prototype.canCopy = function(elements, element) {
+  if (isAny(element, ['bpmn:Participant', 'bpmn:Message'])) {
+    return false;
+  }
+  return BpmnRules.prototype.canCopy.call(this, elements, element);
+};

--- a/lib/features/rules/ChoreoRules.js
+++ b/lib/features/rules/ChoreoRules.js
@@ -32,8 +32,13 @@ ChoreoRules.$inject = ['injector'];
  */
 ChoreoRules.prototype.init = function() {
   let self = this;
+  // WARNING: We call init on BpmnRules at the very END of this init. This is because otherwise bpmn-js' rules
+  // would overwrite our rules, as order matters. (We could potentially also use higher priority, but then we would have
+  // to check what their prio is.) As of bpmn-js 6.5.1 they only have two additional rules 'connection.updateWaypoints'
+  // and 'connection.start'. This might however change in future and break stuff for us if we upgrade. At the same time
+  // stuff might also break if we upgrade and forget to copy a rule so there is no perfect solution.
 
-  // START: Rules from bpmn-js, only the calls to the functions via self are changed
+  // ////// START: Rules from bpmn-js, only the calls to the functions via self are changed
 
   this.addRule('connection.create', function(context) {
     // This function is equivalent to bpmn-js 6.5.1 except for self.canConnect
@@ -144,10 +149,10 @@ ChoreoRules.prototype.init = function() {
     return self.canCopy(elements, element);
   });
 
-  // END: Rules from bpmn-js
+  // ////// END: Rules from bpmn-js
 
 
-  // START: Chor-js specific rules
+  // ////// START: Chor-js specific rules
 
   this.addRule('band.create', function(context) {
     let activityShape = context.activityShape;
@@ -236,6 +241,9 @@ ChoreoRules.prototype.init = function() {
     }
     return false;
   });
+
+  BpmnRules.prototype.init.call(this);
+
 };
 
 ChoreoRules.prototype.canMove = function(shapes, target) {

--- a/lib/features/rules/ChoreoRules.js
+++ b/lib/features/rules/ChoreoRules.js
@@ -38,7 +38,7 @@ ChoreoRules.prototype.init = function() {
   // and 'connection.start'. This might however change in future and break stuff for us if we upgrade. At the same time
   // stuff might also break if we upgrade and forget to copy a rule so there is no perfect solution.
 
-  // ////// START: Rules from bpmn-js, only the calls to the functions via self are changed
+  //////// START: Rules from bpmn-js, only the calls to the functions via self are changed
 
   this.addRule('connection.create', function(context) {
     // This function is equivalent to bpmn-js 6.5.1 except for self.canConnect
@@ -305,13 +305,13 @@ ChoreoRules.prototype.canConnectSequenceFlow = function(source, target) {
   return BpmnRules.prototype.canConnectSequenceFlow.call(this, source, target);
 };
 
-function isConnection(element) {
-  return element.waypoints;
-}
-
 ChoreoRules.prototype.canCopy = function(elements, element) {
   if (isAny(element, ['bpmn:Participant', 'bpmn:Message'])) {
     return false;
   }
   return BpmnRules.prototype.canCopy.call(this, elements, element);
 };
+
+function isConnection(element) {
+  return element.waypoints;
+}

--- a/lib/features/rules/ChoreoRules.js
+++ b/lib/features/rules/ChoreoRules.js
@@ -22,7 +22,7 @@ export default function ChoreoRules(injector) {
 
 inherits(ChoreoRules, BpmnRules);
 
-ChoreoRules.$inject = [ 'injector' ];
+ChoreoRules.$inject = ['injector'];
 
 /**
  * Unfortunately the rules they define in BpmnRules call local methods instead of prototype
@@ -34,6 +34,7 @@ ChoreoRules.prototype.init = function() {
   let self = this;
 
   this.addRule('connection.create', function(context) {
+    // This function is equivalent to bpmn-js 6.5.1 except for self.canConnect
     var source = context.source,
         target = context.target,
         hints = context.hints || {},
@@ -61,6 +62,41 @@ ChoreoRules.prototype.init = function() {
         target.parent = null;
       }
     }
+  });
+
+  this.addRule('connection.reconnect', function(context) {
+    // This function is equivalent to bpmn-js 6.5.1 except for self.canConnect
+    var connection = context.connection,
+        source = context.source,
+        target = context.target;
+
+    return self.canConnect(source, target, connection);
+  });
+
+  this.addRule('shape.resize', function(context) {
+    // This function is equivalent to bpmn-js 6.5.1 except for self.canResize
+    var shape = context.shape,
+        newBounds = context.newBounds;
+
+    return self.canResize(shape, newBounds);
+  });
+
+  this.addRule('elements.create', function(context) {
+    var elements = context.elements,
+        position = context.position,
+        target = context.target;
+
+    return elements.every(function(element) {
+      if (isConnection(element)) {
+        return self.canConnect(element.source, element.target, element);
+      }
+
+      if (element.host) {
+        return self.canAttach(element, element.host, null, position);
+      }
+
+      return self.canCreate(element, target, null, position);
+    });
   });
 
   this.addRule('band.create', function(context) {
@@ -134,34 +170,11 @@ ChoreoRules.prototype.init = function() {
     });
   });
 
-  this.addRule('connection.reconnectStart', function(context) {
-    var connection = context.connection,
-        source = context.hover || context.source,
-        target = connection.target;
 
-    return self.canConnect(source, target, connection);
-  });
-
-  this.addRule('connection.reconnectEnd', function(context) {
-    var connection = context.connection,
-        source = connection.source,
-        target = context.hover || context.target;
-
-    return self.canConnect(source, target, connection);
-  });
-
-  this.addRule('shape.resize', function(context) {
-    var shape = context.shape,
-        newBounds = context.newBounds;
-
-    return self.canResize(shape, newBounds);
-  });
 
   this.addRule('elements.create', function(context) {
-    if (is(context.target, 'bpmn:Participant')) {
-      return false; // elements.paste was removed in diagram-js >= 4. Thus, we have to check here if something can
-      // be created and pasted.
-    }
+    console.log(context);
+
   });
 
   this.addRule('elements.move', function(context) {
@@ -245,6 +258,9 @@ ChoreoRules.prototype.canCreate = function(shape, target, source, position) {
   } else if (is(target, 'bpmn:SubChoreography') && target.collapsed) {
     // elements can not be placed on collapsed sub-choreographies
     return false;
+  } else if (is(target, 'bpmn:Participant')) {
+    return false; // elements.paste was removed in diagram-js >= 4. Thus, we have to check here if something can
+    // be created and pasted.
   }
   return BpmnRules.prototype.canCreate.call(this, shape, target, source, position);
 };
@@ -258,6 +274,9 @@ ChoreoRules.prototype.canConnect = function(source, target, connection) {
   }
   if (is(source, 'bpmn:Participant') || is(target, 'bpmn:Participant')) {
     return false; // To prevent message flow connections
+  }
+  if (is(source, 'bpmn:Choreography') || is(target, 'bpmn:Choreography')) {
+    return false; // Do not connect to root choreography
   }
   return BpmnRules.prototype.canConnect.call(this, source, target, connection);
 };
@@ -279,3 +298,7 @@ ChoreoRules.prototype.canConnectSequenceFlow = function(source, target) {
   }
   return BpmnRules.prototype.canConnectSequenceFlow.call(this, source, target);
 };
+
+function isConnection(element) {
+  return element.waypoints;
+}

--- a/lib/features/rules/ChoreoRules.js
+++ b/lib/features/rules/ChoreoRules.js
@@ -38,7 +38,7 @@ ChoreoRules.prototype.init = function() {
   // and 'connection.start'. This might however change in future and break stuff for us if we upgrade. At the same time
   // stuff might also break if we upgrade and forget to copy a rule so there is no perfect solution.
 
-  //////// START: Rules from bpmn-js, only the calls to the functions via self are changed
+  // ------ START: Rules from bpmn-js, only the calls to the functions via self are changed
 
   this.addRule('connection.create', function(context) {
     // This function is equivalent to bpmn-js 6.5.1 except for self.canConnect
@@ -149,10 +149,10 @@ ChoreoRules.prototype.init = function() {
     return self.canCopy(elements, element);
   });
 
-  // ////// END: Rules from bpmn-js
+  // ------ END: Rules from bpmn-js
 
 
-  // ////// START: Chor-js specific rules
+  // ------ START: Chor-js specific rules
 
   this.addRule('band.create', function(context) {
     let activityShape = context.activityShape;

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "watchify": "^3.11.1"
   },
   "dependencies": {
-    "bpmn-js": "^6.4.1",
-    "diagram-js": "^6.5.0",
+    "bpmn-js": "^6.5.1",
+    "diagram-js": "^6.6.1",
     "inherits": "^2.0.4",
     "min-dash": "^3.5.0",
     "tiny-svg": "^2.2.0"


### PR DESCRIPTION
What seemed to be initially one bug introduced by the upgrade to bpmn-js 6 where actually two bugs. However, what they both had in common was that they resulted from our unclean management of ChoreoRules.js. I cleaned it up, fixed the bugs and left some comments so this will not happen so easily in future. 
The diff looks hard to read, however, I just moved all the rules overwriting bpmn-js to the top. 