### PR TITLE
Connect appended shapes dragged from context pad

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -57,7 +57,9 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
     function appendStart(event, element) {
       var shape = self._elementFactory.createShape(assign({ type: type }, options));
-      self._create.start(event, shape, element);
+      self._create.start(event, shape, {
+        source: element
+      });
     }
 
     var append = self._autoPlace ? function(event, element) {


### PR DESCRIPTION
Fixes #170 

This issue was introduced by the following change in `bpmn-js`: https://github.com/bpmn-io/bpmn-js/commit/14bf3a32ee31990040a2b438367a98a7a1efd92f#diff-4f1febb6aaa185881a563bca38b78d333495455342c3964b899687a7d0c0a2bc

The API to the `create` module was changed, which we did not adapt to on our end.