### PR TITLE
Make Viewer and NavigatedViewer available from Modeler

### DIFF
--- a/docs/prepackaged.html
+++ b/docs/prepackaged.html
@@ -7,7 +7,8 @@
     <meta charset="UTF-8" />
     <title>chor-js prepackaged</title>
 
-    <!-- Import the CSS and Javascript code -->
+    <!-- Import the CSS and Javascript code.
+    If you only want viewing functionality, you can also choose the Viewer or NavigatedViewer scripts -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/chor-js@latest/dist/assets/chor-js.css">
     <script src="https://cdn.jsdelivr.net/npm/chor-js@latest/dist/chor-js-modeler.min.js"></script>
 
@@ -25,7 +26,8 @@
     <div id="canvas"></div>
 
     <script>
-      // Create a new instance of the modeler
+      // Create a new instance of the modeler.
+      // Use `new ChorJS.Viewer({...` to create an instance of only the Viewer
       let bpmnModeler = new ChorJS({
         container: '#canvas',
         keyboard: {

--- a/docs/prepackaged.html
+++ b/docs/prepackaged.html
@@ -7,8 +7,11 @@
     <meta charset="UTF-8" />
     <title>chor-js prepackaged</title>
 
-    <!-- Import the CSS and Javascript code.
-    If you only want viewing functionality, you can also choose the Viewer or NavigatedViewer scripts -->
+    <!--
+      Import the CSS and Javascript code.
+      If you only want viewing functionality, you can also choose the *viewer.min.js or
+      *navigated-viewer.min.js scripts.
+    -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/chor-js@latest/dist/assets/chor-js.css">
     <script src="https://cdn.jsdelivr.net/npm/chor-js@latest/dist/chor-js-modeler.min.js"></script>
 
@@ -22,12 +25,12 @@
   </head>
   <body>
 
-    <!-- Create a canvas for chor-js to use -->
+    <!-- Create a canvas for chor-js to use. -->
     <div id="canvas"></div>
 
     <script>
       // Create a new instance of the modeler.
-      // Use `new ChorJS.Viewer({...` to create an instance of only the Viewer
+      // Use `new ChorJS.Viewer({...})` to create an instance of only the viewer components.
       let bpmnModeler = new ChorJS({
         container: '#canvas',
         keyboard: {
@@ -35,10 +38,10 @@
         }
       });
 
-      // Load the XML of a BPMN choreography model
+      // Load the XML of a BPMN choreography model.
       let diagramUrl = 'https://cdn.jsdelivr.net/gh/bptlab/chor-js@latest/docs/sample.bpmn';
       fetch(diagramUrl).then(response => response.text()).then(async xml => {
-        // Display the model
+        // Display the model.
         await bpmnModeler.importXML(xml);
       });
     </script>

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -3,6 +3,9 @@ import Diagram from 'diagram-js';
 
 import inherits from 'inherits';
 
+import Viewer from './Viewer';
+import NavigatedViewer from './NavigatedViewer';
+
 import CoreModule from './core';
 
 import ContextPadModule from './features/context-pad';
@@ -23,8 +26,6 @@ import {
   displayChoreography,
   clearShapeCache
 } from './import/ImportHandler';
-import Viewer from './Viewer';
-import NavigatedViewer from './NavigatedViewer';
 
 
 /**
@@ -38,7 +39,7 @@ inherits(Modeler, BaseModeler);
 
 module.exports = Modeler; // Required so we can import Modeler in html from a script as ChorJS
 
-// For people who use the prepacked script we also export the viewer versions here
+// For people who use the prepackaged version of chor-js, we also export the viewer versions here
 // so they do not need to include two scripts if they want both
 Modeler.Viewer = Viewer;
 Modeler.NavigatedViewer = NavigatedViewer;

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -23,6 +23,8 @@ import {
   displayChoreography,
   clearShapeCache
 } from './import/ImportHandler';
+import Viewer from './Viewer';
+import NavigatedViewer from './NavigatedViewer';
 
 
 /**
@@ -35,6 +37,11 @@ export default function Modeler(options) {
 inherits(Modeler, BaseModeler);
 
 module.exports = Modeler; // Required so we can import Modeler in html from a script as ChorJS
+
+// For people who use the prepacked script we also export the viewer versions here
+// so they do not need to include two scripts if they want both
+Modeler.Viewer = Viewer;
+Modeler.NavigatedViewer = NavigatedViewer;
 
 Modeler.prototype.open = function(bpmnDiagramOrId) {
   return displayChoreography(this, bpmnDiagramOrId);

--- a/lib/NavigatedViewer.js
+++ b/lib/NavigatedViewer.js
@@ -24,6 +24,10 @@ NavigatedViewer.prototype._navigationModules = [
 
 module.exports = NavigatedViewer; // Required so we can import NViewer in html from a script as ChorJS
 
+// For people who use the prepacked script we also export the viewer version here
+// so they do not need to include two scripts if they want both
+NavigatedViewer.Viewer = Viewer;
+
 NavigatedViewer.prototype._modules = [].concat(
   Viewer.prototype._modules,
   NavigatedViewer.prototype._navigationModules

--- a/lib/NavigatedViewer.js
+++ b/lib/NavigatedViewer.js
@@ -24,7 +24,7 @@ NavigatedViewer.prototype._navigationModules = [
 
 module.exports = NavigatedViewer; // Required so we can import NViewer in html from a script as ChorJS
 
-// For people who use the prepacked script we also export the viewer version here
+// For people who use the prepackaged version of chor-js we also export the plain Viewer here
 // so they do not need to include two scripts if they want both
 NavigatedViewer.Viewer = Viewer;
 


### PR DESCRIPTION
This way users do not have to import another file if they use the prepackaged version. Bpmn-js does the same. Fixes #174 