### PR TITLE
Include artifacts (text annotations) in export

### DIFF
--- a/lib/features/di-ordering/ChoreoDiOrdering.js
+++ b/lib/features/di-ordering/ChoreoDiOrdering.js
@@ -73,7 +73,7 @@ export default function ChoreoDiOrdering(eventBus, canvas, choreoUtil) {
  * @param planeElements
  */
 function getChildrenAndParticipantDIs(choreography, planeElements) {
-  let children = [].concat(choreography.flowElements || []);
+  let children = [].concat(choreography.flowElements || [], choreography.artifacts || []);
   let orderedDIs = [];
   while (children.length > 0) {
     const nextBusinessObject = children.shift();
@@ -87,6 +87,9 @@ function getChildrenAndParticipantDIs(choreography, planeElements) {
     }
     if (nextBusinessObject.flowElements) {
       children = children.concat(nextBusinessObject.flowElements);
+    }
+    if (nextBusinessObject.artifacts) {
+      children = children.concat(nextBusinessObject.artifacts);
     }
   }
   return orderedDIs;


### PR DESCRIPTION
Fixes #177 

Our adaptation of the DI ordering feature of bpmn-js only worked for `FlowElement`s, but artifacts including text annotations and associations are handled differently by the BPMN standard.
The DI ordering now takes this into account.